### PR TITLE
Security: weekly scanning, PR vulnerability gate, dependency patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    groups:
+      jackson:
+        patterns: ["com.fasterxml.jackson*"]
+      twelvemonkeys:
+        patterns: ["com.twelvemonkeys*"]
+      jetty:
+        patterns: ["org.eclipse.jetty*"]
+    ignore:
+      # pdfbox 3.x is a breaking migration (PDF rendering is the core product
+      # path) — majors are deliberate work, not a Monday PR.
+      - dependency-name: "org.apache.pdfbox:pdfbox"
+        update-types: ["version-update:semver-major"]
+      # Jetty 12 moves package namespaces (ee9/ee10) — same reasoning.
+      - dependency-name: "org.eclipse.jetty:*"
+        update-types: ["version-update:semver-major"]
+      # slf4j 2.x changes the binding mechanism; stay on 1.7.x until chosen.
+      - dependency-name: "org.slf4j:*"
+        update-types: ["version-update:semver-major"]
+      # JUnit 5 is a rewrite of the test framework, not a bump.
+      - dependency-name: "junit:junit"
+        update-types: ["version-update:semver-major"]
+      # Internal artifact resolved from the checked-in libs/ file repo;
+      # Dependabot cannot see it.
+      - dependency-name: "com.applitools.eyesutilities:EyesUtilities"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -15,7 +18,7 @@ jobs:
   pii-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Scan tracked files for customer data
         run: bash .githooks/pii-guard.sh --all
 
@@ -23,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 11
@@ -40,9 +43,9 @@ jobs:
     if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 11
@@ -63,15 +66,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -81,7 +84,7 @@ jobs:
         run: mvn -Pgui-installers -DskipTests -Dowasp.skip=true clean verify --batch-mode
 
       - name: Upload installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: imagetester-installer-${{ matrix.os }}
           path: target/installers/*

--- a/.github/workflows/multi-format.yml
+++ b/.github/workflows/multi-format.yml
@@ -1,5 +1,8 @@
 name: multi-format-tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -10,10 +13,10 @@ jobs:
   multi-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags: ['v*']
@@ -16,9 +19,9 @@ jobs:
       version: ${{ steps.ver.outputs.version }}
       tag: ${{ steps.ver.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17
@@ -75,15 +78,15 @@ jobs:
       HAS_WINDOWS_SIGNING: ${{ secrets.WINDOWS_SIGNING_CERT != '' }}
       HAS_APPLE_SIGNING: ${{ secrets.APPLE_SIGNING_CERT != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -125,7 +128,7 @@ jobs:
           mv "$file" "ImageTester-${{ needs.validate.outputs.version }}-${{ matrix.label }}.${ext}"
           ls
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: installer-${{ matrix.label }}
           path: target/installers/*
@@ -135,9 +138,9 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 11
@@ -166,7 +169,7 @@ jobs:
           done
           ls -la ImageTester_*.jar
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cli-jars
           path: jars/ImageTester_*.jar
@@ -179,9 +182,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,74 @@
+name: Security
+
+on:
+  pull_request:
+  schedule:
+    # Monday 05:00 UTC — one hour before Dependabot opens bump PRs, so the
+    # Security tab reflects reality when the PRs arrive.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ---- PR gate: blocks CRITICAL/HIGH introduced by the PR ----
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high
+
+  osv-pr:
+    if: github.event_name == 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+
+  trivy-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+
+  # ---- Weekly audit: full scans, all severities, SARIF to Security tab ----
+
+  osv-audit:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+
+  trivy-audit:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+      - uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>pdfbox</artifactId>
-			<version>2.0.29</version>
+			<version>2.0.37</version>
 		</dependency>
 		<dependency>
 			<groupId>com.applitools</groupId>
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
+			<version>2.22.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -120,12 +120,12 @@
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>jbig2-imageio</artifactId>
-			<version>3.0.4</version>
+			<version>3.0.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
-			<version>5.8</version>
+			<version>5.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -135,7 +135,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.32</version>
+			<version>1.7.36</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -166,12 +166,12 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>11.0.20</version>
+			<version>11.0.26</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>11.0.20</version>
+			<version>11.0.26</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.javakeyring</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,19 @@
 			<version>4.11.0</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- NOTE: jackson must be declared before EyesUtilities: that jar embeds a partial
+		     unrelocated jackson-core 2.16.1 fragment; first-on-classpath must be the real,
+		     coherent jackson or newer jackson classes hit NoSuchMethodError. -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.22.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-csv</artifactId>
+			<version>2.22.1</version>
+		</dependency>
 		<dependency>
 			<groupId>com.applitools.eyesutilities</groupId>
 			<artifactId>EyesUtilities</artifactId>
@@ -113,11 +126,6 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>2.13.4</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>jbig2-imageio</artifactId>
 			<version>3.0.5</version>
@@ -126,11 +134,6 @@
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
 			<version>5.12.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.dataformat</groupId>
-			<artifactId>jackson-dataformat-csv</artifactId>
-			<version>2.13.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-07-27-security-scanning-design.md:

- Weekly Dependabot bump PRs (maven + github-actions), grouped, majors held back for pdfbox/jetty/slf4j/junit
- security.yml: PR gate (dependency-review + OSV diff scan + Trivy, CRITICAL/HIGH fixable) and weekly Monday audit (full scans, SARIF to Security tab, includes the checked-in libs/EyesUtilities jar)
- Existing workflows SHA-pinned with least-privilege permissions
- Backlog patch: jackson 2.22.1, commons-io 2.22.0, pdfbox 2.0.37, opencsv 5.12.0, jetty 11.0.26, slf4j 1.7.36, jbig2-imageio 3.0.5
- Fixes latent classpath shadowing: jackson must be declared before EyesUtilities (that jar embeds a partial unrelocated jackson-core 2.16.1 fragment); NOTE comment in pom.xml guards the ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)