### PR TITLE
ci(security): keep weekly osv-audit green, report via SARIF

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,6 +53,9 @@ jobs:
       contents: read
       security-events: write
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      # Audit reports via SARIF; job status should mean "scan ran", not "repo has vulns".
+      fail-on-vuln: false
 
   trivy-audit:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
One-line follow-up from the security-setup final review: pass fail-on-vuln: false to the osv-audit reusable workflow call so the weekly run's status means the scan ran, not that the repo has zero findings (that signal lives in the Security tab). The PR gate osv-pr is unchanged and still fails on newly introduced vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)